### PR TITLE
Large clean-up of cumulative method

### DIFF
--- a/hmp/models/cumulative.py
+++ b/hmp/models/cumulative.py
@@ -219,6 +219,7 @@ class CumulativeMethod(BaseModel):
             # look between which event the next proposition should go
             n_event_j = np.argwhere(scale_j >= np.cumsum(time_pars_props[:, 1])) + 2
             n_event_j = np.max(n_event_j) if len(n_event_j) > 0 else 1
+            n_event_j = np.min([n_event_j, n_events])  # do not insert even after last stage
 
             # insert j at right spot, subtract prev scales
             time_pars_props = np.insert(

--- a/hmp/models/cumulative.py
+++ b/hmp/models/cumulative.py
@@ -62,8 +62,7 @@ class CumulativeMethod(BaseModel):
         self.end = end
         self.fastforward = fastforward
         self.tolerance = tolerance
-        self.submodels = {}
-        self.final_model = None
+        self.submodels = []
         super().__init__(*args, **kwargs)
 
     def fit(
@@ -134,7 +133,7 @@ class CumulativeMethod(BaseModel):
             # check solution
             if likelihoods - lkh_prev > 0:  # accept solution if likelihood improved
                 lkh_prev = likelihoods
-                self.submodels[n_events] = event_model
+                self.submodels.append(event_model)
 
                 # update channel_pars, params,
                 channel_pars[:n_events] = event_model.channel_pars
@@ -168,29 +167,17 @@ class CumulativeMethod(BaseModel):
 
         # done estimating
         n_events = n_events - 1
-        channel_pars = channel_pars[:n_events, :]
-        time_pars = time_pars[: n_events + 1, :]
-
-        self.final_model = EventModel(
-            self.pattern, self.distribution, tolerance=self.tolerance,
-            n_events=n_events)
         if n_events > 0:
-            self.final_model.fit(
-                trial_data,
-                channel_pars=np.array([[channel_pars]]),
-                time_pars=np.array([[time_pars]]),
-                verbose=verbose,
-                cpus=1,
-            )
+            if verbose:
+                print(f"Found {n_events} events")
             self._fitted = True
-
         else:
             warn("Failed to find more than two stages, returning None")
             self._fitted = False
 
     def transform(self, *args, **kwargs):
         """
-        Transform the input data using the fitted cumulative event model.
+        Transform the input data using the last model fitted in the cumulative method.
 
         This method applies the transformation defined by the final model to the provided data.
 
@@ -200,11 +187,8 @@ class CumulativeMethod(BaseModel):
 
         """
         self._check_fitted("transform data")
-        if self.final_model is not None:
-            return self.final_model.transform(*args, **kwargs)
-        else:
-            raise RuntimeError("No fitted model available to transform data.")
-
+        return self.submodels[-1].transform(*args, **kwargs)
+        
     def _propose_fit_params(self, n_events, j, channel_pars, time_pars):
 
         if (

--- a/hmp/models/cumulative.py
+++ b/hmp/models/cumulative.py
@@ -36,7 +36,7 @@ class CumulativeMethod(BaseModel):
     end : int, optional
         The maximum number of samples to explore within each trial. Defaults to None.
     fastforward : bool, optional
-        If True cumulatively estimates HMP models by looking for a new event after the 
+        If True cumulatively estimates HMP models by looking for a new event after the
         last event that improved likelihood. This fastforward version uses shortcuts to speed
         estimation but can miss events in-between two events.
         If False (Default) iteratively test all samples from `start` to `end`, retain times at
@@ -55,7 +55,7 @@ class CumulativeMethod(BaseModel):
         step: float = None,
         end: int = None,
         fastforward: bool = True,
-        tolerance: float = 1e-4
+        tolerance: float = 1e-4,
         **kwargs,
     ):
         self.step = step
@@ -106,11 +106,11 @@ class CumulativeMethod(BaseModel):
 
         # Initialize last stage of n=1
         time_pars[0, 1] = self.distribution.mean_to_scale(trial_data.durations.mean())
-        
+
         # final channel_pars during estimation
         channel_pars = np.zeros((int(end/self.step), trial_data.n_dims))
         lkh_prev = -np.inf
-        
+
         # Iterative fit
         while j*self.step < end:
             prev_j = j
@@ -142,8 +142,10 @@ class CumulativeMethod(BaseModel):
 
                 if verbose:
                     # Just to track advancement
-                    events_so_far = [int(np.round(self.distribution.scale_to_mean(x))*(1000/self.sfreq)) for x in 
-                                np.cumsum(event_model.time_pars[0, :n_events, 1])
+                    events_so_far = [int(np.round(self.distribution.scale_to_mean(x))
+                                         *(1000/self.sfreq))
+                                         for x in
+                                     np.cumsum(event_model.time_pars[0, :n_events, 1])
                     ]
                     print(
                         f"{n_events} events found around times "
@@ -151,9 +153,9 @@ class CumulativeMethod(BaseModel):
                     )
                 # Search for additional event
                 n_events += 1
-            
+
             if self.fastforward:
-                # # If ffwd, the next sample tested follows the last explored time 
+                # # If ffwd, the next sample tested follows the last explored time
                 max_scale = np.max(
                     [np.sum(x[0, :n_events-1, 1]) for x in event_model.time_pars_dev]
                 )
@@ -227,12 +229,14 @@ class CumulativeMethod(BaseModel):
             # subtract inserted scale from next event
             time_pars_props[n_event_j, 1] = (time_pars_props[n_event_j, 1]
                                              - time_pars_props[n_event_j - 1, 1])
-            channel_pars_props = np.zeros((1, n_events, channel_pars.shape[-1]))  # always 0            
+            channel_pars_props = np.zeros((1, n_events, channel_pars.shape[-1]))  # always 0
         else:
             time_pars_props = time_pars[: n_events + 1].copy()
             time_pars_props[n_events,1] = time_pars_props[n_events-1,1]
             # New parameter proposition for the new event based on previous run
-            new_event_prop = np.max([self.distribution.mean_to_scale(j * self.step) - np.sum(time_pars_props[:n_events-1, 1]), self.distribution.mean_to_scale(self.step)])
+            new_event_prop = (np.max([self.distribution.mean_to_scale(j * self.step) -
+                np.sum(time_pars_props[:n_events-1, 1]),self.distribution.mean_to_scale(self.step)])
+            )
             time_pars_props[n_events-1, 1] = new_event_prop
             # Subtract new proposition from last stage
             time_pars_props[-1, 1] -= new_event_prop
@@ -241,11 +245,11 @@ class CumulativeMethod(BaseModel):
             channel_pars_props = np.zeros((1, n_events, channel_pars.shape[-1]))
             channel_pars_props[:, :n_events-1, :] = channel_pars[:n_events-1]
 
-        # Ensures non-negative time parameters, exclusively (?) happening for last 
+        # Ensures non-negative time parameters, exclusively (?) happening for last
         # sample when step > remainder
         time_pars_props[:, 1] = np.maximum(time_pars_props[:, 1],
                                            self.distribution.mean_to_scale(1))
-        
+
         return channel_pars_props, np.array([time_pars_props])
 
     def __getattribute__(self, attr):

--- a/hmp/models/cumulative.py
+++ b/hmp/models/cumulative.py
@@ -45,8 +45,6 @@ class CumulativeMethod(BaseModel):
     tolerance : float, optional
         The tolerance used for convergence in the EM() function for the cumulative step.
         Defaults to 1e-4.
-    final_model_tolerance : float, optional
-        The tolerance used for the final model. Defaults to 1e-4.
     kwargs : dict
         Additional keyword arguments to be passed to the BaseModel.
     """
@@ -57,16 +55,13 @@ class CumulativeMethod(BaseModel):
         step: float = None,
         end: int = None,
         fastforward: bool = True,
-        tolerance: float = 1e-4,
-        final_model_tolerance: float = 1e-4,
+        tolerance: float = 1e-4
         **kwargs,
     ):
         self.step = step
         self.end = end
         self.fastforward = fastforward
         self.tolerance = tolerance
-        self.final_model_tolerance = (tolerance if final_model_tolerance is None
-                                      else final_model_tolerance)
         self.submodels = {}
         self.final_model = None
         super().__init__(*args, **kwargs)
@@ -175,7 +170,7 @@ class CumulativeMethod(BaseModel):
         time_pars = time_pars[: n_events + 1, :]
 
         self.final_model = EventModel(
-            self.pattern, self.distribution, tolerance=self.final_model_tolerance,
+            self.pattern, self.distribution, tolerance=self.tolerance,
             n_events=n_events)
         if n_events > 0:
             self.final_model.fit(

--- a/hmp/models/cumulative.py
+++ b/hmp/models/cumulative.py
@@ -188,7 +188,7 @@ class CumulativeMethod(BaseModel):
         """
         self._check_fitted("transform data")
         return self.submodels[-1].transform(*args, **kwargs)
-        
+
     def _propose_fit_params(self, n_events, j, channel_pars, time_pars):
 
         if (

--- a/hmp/models/cumulative.py
+++ b/hmp/models/cumulative.py
@@ -30,14 +30,17 @@ class CumulativeMethod(BaseModel):
         Extra arguments to be passed to the BaseModel, including at least events and
         distribution objects.
     step : float, optional
-        The size of the step from 0 to the mean RT. Defaults to the width of the expected event.
+        The size of the step from 0 to the mean RT. Defaults to the location defined in the pattern.
+        Small values ensure a complete exploration of the parameter space but can be slow.
+        Higher values fasten the estimation but risk missing event due to unexplored spaces.
     end : int, optional
         The maximum number of samples to explore within each trial. Defaults to None.
-    by_sample : bool, optional
-        If True, tries every sample as the starting point, even if a later event has already been
-        identified.
-        This is useful in cases where the method might jump over a local maximum in an earlier
-        estimation. Defaults to False.
+    fastforward : bool, optional
+        If True cumulatively estimates HMP models by looking for a new event after the 
+        last event that improved likelihood. This fastforward version usees shortcut to speed
+        estimation but can miss events in-between two events with large SNR.
+        If False (Default) iteratively test all samples from `start` to `end`, retain times at
+        which likelihood increased regardless of whether a subsequent event was found.
     tolerance : float, optional
         The tolerance used for convergence in the EM() function for the cumulative step.
         Defaults to 1e-4.
@@ -52,14 +55,14 @@ class CumulativeMethod(BaseModel):
         *args,
         step: float = None,
         end: int = None,
-        by_sample: bool = False,
+        fastforward: bool = True,
         tolerance: float = 1e-4,
         final_model_tolerance: float = 1e-4,
         **kwargs,
     ):
         self.step = step
         self.end = end
-        self.by_sample = by_sample
+        self.fastforward = fastforward
         self.tolerance = tolerance
         self.final_model_tolerance = (tolerance if final_model_tolerance is None
                                       else final_model_tolerance)
@@ -67,7 +70,7 @@ class CumulativeMethod(BaseModel):
         self.final_model = None
         super().__init__(*args, **kwargs)
 
-    def fit(  # noqa: PLR0915
+    def fit(
         self,
         trial_data: TrialData,
         verbose: bool = True,
@@ -96,42 +99,31 @@ class CumulativeMethod(BaseModel):
         """
         self.trial_data = trial_data
         end = trial_data.durations.mean() if self.end is None else self.end
-        step = self.event_width if self.step is None else self.step
+        self.step = self.location if self.step is None else self.step
 
-        max_event_n = self.compute_max_events(trial_data)
-
-        pbar = tqdm(total=int(np.rint(end)))  # progress bar
-        n_events, j, time = 1, 1, 0  # j = sample after last placed event
-        # Init time_pars (need this for min_model)
-        time_pars = np.zeros((max_event_n + 1, 2))
+        pbar = tqdm(total=int(np.rint(end/self.step+1)))  # progress bar
+        n_events, j = 1, 1 # j = sample after last placed event
 
         # final time parameters during estimation, shape x scale
+        time_pars = np.zeros((int(end/self.step), 2))
         time_pars[:, 0] = self.distribution.shape
-        time_pars_props = time_pars[: n_events + 1].copy()  # gamma params of current estimation
-        # initialize time parameter at 1 sample
-        time_pars_props[0, 1] = self.distribution.mean_to_scale(j * step)
-        last_stage = self.distribution.mean_to_scale(end - j * step)  # remainder of time
-        time_pars_props[-1, 1] = last_stage
 
-        # Init channel_pars
+        # Initialize last stage of n=1
+        time_pars[0, 1] = self.distribution.mean_to_scale(trial_data.durations.mean())
+        
         # final channel_pars during estimation
-        channel_pars = np.zeros((max_event_n, trial_data.n_dims))
+        channel_pars = np.zeros((int(end/self.step), trial_data.n_dims))
         lkh_prev = -np.inf
-
+        
         # Iterative fit
-        while (
-            self.distribution.scale_to_mean(last_stage) >= self.location and n_events <= max_event_n
-        ):
-            prev_time = time
+        while j*self.step < end:
+            prev_j = j
             event_model = EventModel(self.pattern, self.distribution, tolerance=self.tolerance,
                                      n_events=n_events)
             # get new parameters
-            channel_pars_props, time_pars_props = self._propose_fit_params(
-                trial_data,
-                n_events, self.by_sample, step, j, channel_pars, time_pars, end
+            j, channel_pars_props, time_pars_props = self._propose_fit_params(
+                n_events, j, channel_pars, time_pars
             )
-            last_stage = time_pars_props[n_events, 1]
-            time_pars_props = np.array([time_pars_props])
 
             # Estimate model based on these propositions
             event_model.fit(
@@ -141,68 +133,43 @@ class CumulativeMethod(BaseModel):
                 verbose=False,
                 cpus=cpus,
             )
-            self.submodels[n_events] = event_model
-            sol_sample_new_event = int(
-                np.round(
-                    self.distribution.scale_to_mean(
-                        np.sum(event_model.time_pars[0, :n_events, 1])
-                    )
-                )
-            )
+
             likelihoods = event_model.lkhs.sum()
             # check solution
             if likelihoods - lkh_prev > 0:  # accept solution if likelihood improved
                 lkh_prev = likelihoods
+                self.submodels[n_events] = event_model
 
                 # update channel_pars, params,
                 channel_pars[:n_events] = event_model.channel_pars
                 time_pars[: n_events + 1] = event_model.time_pars
 
-                # search for an additional event, starting again at sample 1 from prev event,
-                # or next sample if by_sample
-                n_events += 1
-                if self.by_sample:
-                    j += 1
-                    time = j * step
-                else:
-                    j = 1
-                    time = sol_sample_new_event + j * step
-
-                # Diagnostic plot
                 if verbose:
+                    # Just to track advancement
+                    events_so_far = [int(np.round(self.distribution.scale_to_mean(x))*(1000/self.sfreq)) for x in 
+                                np.cumsum(event_model.time_pars[0, :n_events, 1])
+                    ]
                     print(
-                        f"Transition event {n_events - 1} found around time "
-                        f"{sol_sample_new_event*(1000/self.sfreq)}"
+                        f"{n_events} events found around times "
+                        f"{events_so_far}"
                     )
-
-            else:  # reject solution, search on
-                prev_sample = int(
-                    np.round(self.distribution.scale_to_mean(np.sum(time_pars[: n_events - 1, 1])))
+                # Search for additional event
+                n_events += 1
+            
+            if self.fastforward:
+                # # If ffwd, the next sample tested follows the last explored time 
+                max_scale = np.max(
+                    [np.sum(x[0, :n_events-1, 1]) for x in event_model.time_pars_dev]
                 )
-                # find furthest explored param. Note: this also work by_sample
-                # just a tiny bit faster this way
-                if not self.by_sample:
-                    max_scale = np.max(
-                        [np.sum(x[:n_events, 1]) for x in event_model.time_pars_dev]
-                    )
-                    max_sample = int(np.round(self.distribution.scale_to_mean(max_scale)))
-                    j = (
-                        np.max([max_sample - prev_sample + 1, (j + 1) * step]) / step
-                    )  # either ffwd to furthest explored sample or add 1 to j
-                    time = prev_sample + j * step
-                else:
-                    j += 1
-                    time = j * step
-
-            pbar.update(int(np.rint(time - prev_time)))
+                max_sample = int(np.round(self.distribution.scale_to_mean(max_scale)))
+                j = np.max([max_sample, (j + 1) * self.step]) / self.step
+            else:
+                j += 1
+            pbar.update(int(np.rint(j-prev_j)))
+        pbar.update(int(np.rint(end/self.step -j)))
 
         # done estimating
-
         n_events = n_events - 1
-        if verbose:
-            print()
-            print("All events found, refitting final combination.")
-
         channel_pars = channel_pars[:n_events, :]
         time_pars = time_pars[: n_events + 1, :]
 
@@ -222,7 +189,6 @@ class CumulativeMethod(BaseModel):
         else:
             warn("Failed to find more than two stages, returning None")
             self._fitted = False
-        pbar.update(int(np.rint(end) - int(np.rint(time))))
 
     def transform(self, *args, **kwargs):
         """
@@ -241,19 +207,18 @@ class CumulativeMethod(BaseModel):
         else:
             raise RuntimeError("No fitted model available to transform data.")
 
-    def _propose_fit_params(self, trial_data, n_events, by_sample, step, j, channel_pars, time_pars,
-                            end):
+    def _propose_fit_params(self, n_events, j, channel_pars, time_pars):
+
         if (
-            by_sample and n_events > 1
+            not self.fastforward and n_events > 1
         ):  # go through the whole range sample-by-sample, j is sample since start
-            scale_j = self.distribution.mean_to_scale(step * j)
+            scale_j = self.distribution.mean_to_scale(self.step * j)
 
             # New parameter proposition
             time_pars_props = time_pars[:n_events].copy()  # time_pars so far
-            # counting from 1
-            n_event_j = np.argwhere(scale_j > np.cumsum(time_pars_props[:, 1])) + 2
+            # look between which event the next proposition should go
+            n_event_j = np.argwhere(scale_j >= np.cumsum(time_pars_props[:, 1])) + 2
             n_event_j = np.max(n_event_j) if len(n_event_j) > 0 else 1
-            n_event_j = np.min([n_event_j, n_events])  # do not insert even after last stage
 
             # insert j at right spot, subtract prev scales
             time_pars_props = np.insert(
@@ -265,34 +230,25 @@ class CumulativeMethod(BaseModel):
             # subtract inserted scale from next event
             time_pars_props[n_event_j, 1] = (time_pars_props[n_event_j, 1]
                                              - time_pars_props[n_event_j - 1, 1])
-            last_stage = self.distribution.mean_to_scale(end) - np.sum(time_pars_props[:-1, 1])
-            time_pars_props[n_events, 1] = last_stage
-            channel_pars_props = np.zeros((1, n_events, trial_data.n_dims))  # always 0?
-            channel_pars_props[:, : n_events - 1, :] = np.tile(
-                channel_pars[: n_events - 1, :], (len(channel_pars_props), 1, 1)
-            )
-            # shift new event to correct position
-            channel_pars_props = np.insert(
-                channel_pars_props[:, :-1, :], n_event_j - 1, channel_pars_props[:, -1, :], axis=1
-            )
-
+            channel_pars_props = np.zeros((1, n_events, channel_pars.shape[-1]))  # always 0            
         else:
-            # New parameter proposition
             time_pars_props = time_pars[: n_events + 1].copy()
-            time_pars_props[n_events - 1, 1] = self.distribution.mean_to_scale(step * j)
-            last_stage = self.distribution.mean_to_scale(end) - np.sum(time_pars_props[:-1, 1])
-            time_pars_props[n_events, 1] = last_stage
+            time_pars_props[n_events,1] = time_pars_props[n_events-1,1]
+            # New parameter proposition for the new event based on previous run
+            new_event_prop = np.max([self.distribution.mean_to_scale(j * self.step) - np.sum(time_pars_props[:n_events-1, 1]), self.distribution.mean_to_scale(self.step)])
+            time_pars_props[n_events-1, 1] = new_event_prop
+            # Subtract new proposition from last stage
+            time_pars_props[-1, 1] -= new_event_prop
 
-            channel_pars_props = np.zeros((1, n_events, trial_data.n_dims))  # always 0?
-            channel_pars_props[:, : n_events - 1, :] = np.tile(
-                channel_pars[: n_events - 1, :], (len(channel_pars_props), 1, 1)
-            )
+            # Add a neutral event as new proposition
+            channel_pars_props = np.zeros((1, n_events, channel_pars.shape[-1]))
+            channel_pars_props[:, :n_events-1, :] = channel_pars[:n_events-1]
 
-        # in edge cases scale can get negative, make sure that doesn't happen:
+        # Ensures non-negative time parameters, exclusively (?) 
         time_pars_props[:, 1] = np.maximum(time_pars_props[:, 1],
                                            self.distribution.mean_to_scale(1))
-
-        return channel_pars_props, time_pars_props
+        
+        return j, channel_pars_props, np.array([time_pars_props])
 
     def __getattribute__(self, attr):
         property_list = {

--- a/hmp/models/cumulative.py
+++ b/hmp/models/cumulative.py
@@ -37,10 +37,11 @@ class CumulativeMethod(BaseModel):
         The maximum number of samples to explore within each trial. Defaults to None.
     fastforward : bool, optional
         If True cumulatively estimates HMP models by looking for a new event after the 
-        last event that improved likelihood. This fastforward version usees shortcut to speed
-        estimation but can miss events in-between two events with large SNR.
+        last event that improved likelihood. This fastforward version uses shortcuts to speed
+        estimation but can miss events in-between two events.
         If False (Default) iteratively test all samples from `start` to `end`, retain times at
-        which likelihood increased regardless of whether a subsequent event was found.
+        which likelihood increased regardless of whether a subsequent event was found. The N+1
+        solution only retains the time parameters found with the N solution.
     tolerance : float, optional
         The tolerance used for convergence in the EM() function for the cumulative step.
         Defaults to 1e-4.

--- a/hmp/models/cumulative.py
+++ b/hmp/models/cumulative.py
@@ -121,7 +121,7 @@ class CumulativeMethod(BaseModel):
             event_model = EventModel(self.pattern, self.distribution, tolerance=self.tolerance,
                                      n_events=n_events)
             # get new parameters
-            j, channel_pars_props, time_pars_props = self._propose_fit_params(
+            channel_pars_props, time_pars_props = self._propose_fit_params(
                 n_events, j, channel_pars, time_pars
             )
 
@@ -245,11 +245,12 @@ class CumulativeMethod(BaseModel):
             channel_pars_props = np.zeros((1, n_events, channel_pars.shape[-1]))
             channel_pars_props[:, :n_events-1, :] = channel_pars[:n_events-1]
 
-        # Ensures non-negative time parameters, exclusively (?) 
+        # Ensures non-negative time parameters, exclusively (?) happening for last 
+        # sample when step > remainder
         time_pars_props[:, 1] = np.maximum(time_pars_props[:, 1],
                                            self.distribution.mean_to_scale(1))
         
-        return j, channel_pars_props, np.array([time_pars_props])
+        return channel_pars_props, np.array([time_pars_props])
 
     def __getattribute__(self, attr):
         property_list = {

--- a/tests/test_cumulative.py
+++ b/tests/test_cumulative.py
@@ -34,7 +34,7 @@ def test_cumulative_simple():
     true_loglikelihood, true_estimates = true_model.transform(trial_data_b)
 
     # Cumulative estimation
-    model = CumulativeMethod(event_properties, by_sample=True, end=20)
+    model = CumulativeMethod(event_properties, fastforward=False, end=20)
     model.fit(trial_data_b)
     estimates = model.transform(trial_data_b)
 


### PR DESCRIPTION
For maintenance and readability,  + changed name (and behavior) of `by_sample`

- By default the `step` is = to the location which makes sense given that this is the minimum duration (for now)
- Simplified termination rule
- Replaced `by_sample=False` with `fastforward = True` as name is more explicit
- The shortcut of looking for the max explored time (when  `fastforward = True`) as next starting point is used both if proposal was rejected or accepted
- When using  `fastforward = False` (so `by_sample=True `) do not store the channel parameters as their is an ambiguities as to which event these should be assigned to and we may trap the search algorithm because of an ill-defined starting point. Thus just store time pars and start fresh on channels
- Only store the submodels for accepted proposition (before accepted also the last solution, which didn't make sense)
- Removed `final_model_tolerance` as users can always refit with higher tolerance if that was ever useful (I added it but never actually used it)
- made the step (`j`) coherent when using `fastforward` True or False (always indexes progress)
- TQDM progress bar indexes the steps instead of the samples
- Output while fitting gives the array of times where events were found instead of the index of the last event
- Removed max_event_n as not useful and confusing
- improved docstrings following all these changes